### PR TITLE
Adding weighted nls functionality

### DIFF
--- a/R/nls_multstart.R
+++ b/R/nls_multstart.R
@@ -34,6 +34,7 @@
 #'  vector input for \code{iter}.
 #' @param control specific control can be specified using
 #'  \code{\link[minpack.lm]{nls.lm.control}}.
+#' @param weights an optional numeric vector of weights for the nls.
 #' @param \dots Extra arguments to pass to \code{\link[minpack.lm]{nlsLM}} if
 #'  necessary.
 #' @return returns a nls object of the best estimated model fit
@@ -74,7 +75,8 @@
 nls_multstart <-
   # arguments needed for nls_multstart ####
   function(formula, data = parent.frame(), iter, start_lower, start_upper,
-           supp_errors = c("Y", "N"), convergence_count = 100, control, ...) {
+           supp_errors = c("Y", "N"), convergence_count = 100, control,
+           weights, ...) {
 
     # set default values
     if (missing(supp_errors)) {
@@ -197,7 +199,8 @@ nls_multstart <-
             formula,
             start = start.vals,
             control = control,
-            data = data, ...
+            data = data,
+            weights = weights, ...
           ),
           silent = silent
         )
@@ -245,7 +248,8 @@ nls_multstart <-
             formula,
             start = start.vals,
             control = control,
-            data = data, ...
+            data = data,
+            weights = weights, ...
           ),
           silent = silent
         )
@@ -265,7 +269,8 @@ nls_multstart <-
         formula,
         start = allfits$startpars[[1]],
         control = control,
-        data = data, ...
+        data = data,
+        weights = weights, ...
       )
     }
 

--- a/man/nls_multstart.Rd
+++ b/man/nls_multstart.Rd
@@ -5,7 +5,7 @@
 \title{Finds the best fit of non-linear model based on AIC score}
 \usage{
 nls_multstart(formula, data = parent.frame(), iter, start_lower, start_upper,
-  supp_errors = c("Y", "N"), convergence_count = 100, control, ...)
+  supp_errors = c("Y", "N"), convergence_count = 100, control, weights, ...)
 }
 \arguments{
 \item{formula}{a non-linear model formula, with the response on the left of a
@@ -46,6 +46,8 @@ vector input for \code{iter}.}
 
 \item{control}{specific control can be specified using
 \code{\link[minpack.lm]{nls.lm.control}}.}
+
+\item{weights}{an optional numeric vector of weights for the nls.}
 
 \item{\dots}{Extra arguments to pass to \code{\link[minpack.lm]{nlsLM}} if
 necessary.}


### PR DESCRIPTION
Added weights as an input argument.  If missing, minpack.lm deals with it as a missing object.  But adding it here as an input argument gets around minpack.lm's non-standard evaluation of weights, at least as I understand it.