### PR TITLE
Update tidyr nest syntax in nls_multstart without convergence_count

### DIFF
--- a/R/nls_multstart.R
+++ b/R/nls_multstart.R
@@ -249,7 +249,7 @@ nls_multstart <-
     if (convergence_count == FALSE) {
       strt$iteration <- 1:nrow(strt)
 
-      allfits <- tidyr::nest(strt, -iteration, .key = "startpars")
+      allfits <- tidyr::nest(strt, startpars = -iteration)
 
 
       # create empty fit


### PR DESCRIPTION
I was having warnings about the new tidyr::nest() syntax, so I've updated the function accordingly.