### PR TITLE
Improved the error message when the number of parameters is not matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Non-linear least squares regression with the Levenberg-Marquardt al
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Depends:
     R (>= 3.2.1)
 Imports: minpack.lm,

--- a/R/nls_multstart.R
+++ b/R/nls_multstart.R
@@ -20,7 +20,7 @@
 #'  will default to -1e+10.
 #' @param start_upper upper boundaries for the start parameters. If missing, this
 #'  will default to 1e+10.
-#' @param supp_errors if \code{supp_errors = 'Y'}, then warning messages will be suppressed and no error messages from
+#' @param supp_errors if \code{supp_errors = 'Y'}, then no error messages from
 #' \code{\link[minpack.lm]{nlsLM}} will be shown, reducing the number of error messages printed while the model attempts to converge using poor starting parameters.
 #' We advise to only use \code{supp_errors = 'Y'} when confident in the bounds of
 #'  your starting parameters.
@@ -118,7 +118,15 @@ nls_multstart <-
     if (missing(start_upper)) start_upper <- rep(10 ^ 10, length(params_est))
 
     if (length(start_lower) != length(params_est) || length(start_upper) != length(params_est)) {
-      stop("There must be as many parameter starting bounds as there are parameters")
+      stop(paste0(
+        "There must be as many parameter starting bounds as there are parameters.\n\n",
+        "Parameters to estimate:              ", paste(params_est, collapse=" "),"\n",
+        "Parameters supplied as input data:   ", paste(params_ind, collapse=" "),"\n",
+        "Number of parameters in start_lower: ", length(start_lower),"\n",
+        "Number of parameters in start_upper: ", length(start_upper),"\n\n",
+        "If there are parameters listed as input data which should be estimated,\n",
+        "this can be caused by variables in the environment/data with the same\n",
+        "name as model parameters."))
     }
 
     params_bds <- data.frame(
@@ -136,12 +144,6 @@ nls_multstart <-
 
     # transform input arguments
     silent <- ifelse(supp_errors == "Y", TRUE, FALSE)
-
-    # if silent is TRUE, temporarily switch off warnings
-    if(silent == TRUE){
-      oo <- options(warn=-1)
-      on.exit(options(oo))
-    }
 
     if ("modelweights" %in% all.vars(formula)) {
       stop(paste0(
@@ -219,7 +221,6 @@ nls_multstart <-
         start.vals <- as.list(strt[j, ])
 
         # try and fit the model for every set of searching parameters
-
         try(
           fit <- minpack.lm::nlsLM(
             formula,

--- a/R/nls_multstart.R
+++ b/R/nls_multstart.R
@@ -1,50 +1,53 @@
 #' Finds the best fit of non-linear model based on AIC score
 #'
-#' Finds the best estimated model using non-linear least squares regression using
-#' nlsLM(). The best fit is determined using AIC scores.
+#' Finds the best estimated model using non-linear least squares regression
+#' using nlsLM(). The best fit is determined using AIC scores.
 #'
 #' @param formula a non-linear model formula, with the response on the left of a
-#'  ~ operator and an expression involving parameters on the right.
+#'   ~ operator and an expression involving parameters on the right.
 #' @param data (optional) data.frame, list or environment in which to evaluate
-#'  the variables in \code{formula} and \code{modelweights}.
+#'   the variables in \code{formula} and \code{modelweights}.
 #' @param iter number of combinations of starting parameters which will be tried
-#'  . If a single value is provided, then a shotgun/random-search approach will
-#'  be used to sample starting parameters from a uniform distribution within the
-#'  starting parameter bounds. If a vector of the same length as the number of
-#'  parameters is provided, then a gridstart approach will be used to define
-#'  each combination of that number of equally spaced intervals across each of
-#'  the starting parameter bounds respectively. Thus, c(5,5,5) for three fitted
-#'  parameters yields 125 model fits.  Supplying a vector for \code{iter}
-#'  will override \code{convergence_count}.
-#' @param start_lower lower boundaries for the start parameters. If missing, this
-#'  will default to -1e+10.
-#' @param start_upper upper boundaries for the start parameters. If missing, this
-#'  will default to 1e+10.
-#' @param supp_errors if \code{supp_errors = 'Y'}, then no error messages from
-#' \code{\link[minpack.lm]{nlsLM}} will be shown, reducing the number of error messages printed while the model attempts to converge using poor starting parameters.
-#' We advise to only use \code{supp_errors = 'Y'} when confident in the bounds of
-#'  your starting parameters.
-#' @param convergence_count The number of counts that the winning model should be
-#'  undefeated for before it is declared the winner. This argument defaults to
-#'  100. If specified as \code{FALSE}, then all of the iterations will be fitted, and
-#'  the best model selected. Note that \code{convergence_count} can only be used
-#'  with a shotgun/random-search approach, and not with a gridstart approach.
-#'  This argument will be ignored if a gridstart approach is specified by a
-#'  vector input for \code{iter}.
+#'   . If a single value is provided, then a shotgun/random-search approach will
+#'   be used to sample starting parameters from a uniform distribution within
+#'   the starting parameter bounds. If a vector of the same length as the number
+#'   of parameters is provided, then a gridstart approach will be used to define
+#'   each combination of that number of equally spaced intervals across each of
+#'   the starting parameter bounds respectively. Thus, c(5,5,5) for three fitted
+#'   parameters yields 125 model fits.  Supplying a vector for \code{iter} will
+#'   override \code{convergence_count}.
+#' @param start_lower lower boundaries for the start parameters. If missing,
+#'   this will default to -1e+10.
+#' @param start_upper upper boundaries for the start parameters. If missing,
+#'   this will default to 1e+10.
+#' @param supp_errors if \code{supp_errors = 'Y'}, then warning messages will be
+#'   suppressed and no error messages from \code{\link[minpack.lm]{nlsLM}} will
+#'   be shown, reducing the number of error messages printed while the model
+#'   attempts to converge using poor starting parameters. We advise to only use
+#'   \code{supp_errors = 'Y'} when confident in the bounds of your starting
+#'   parameters.
+#' @param convergence_count The number of counts that the winning model should
+#'   be undefeated for before it is declared the winner. This argument defaults
+#'   to 100. If specified as \code{FALSE}, then all of the iterations will be
+#'   fitted, and the best model selected. Note that \code{convergence_count} can
+#'   only be used with a shotgun/random-search approach, and not with a
+#'   gridstart approach. This argument will be ignored if a gridstart approach
+#'   is specified by a vector input for \code{iter}.
 #' @param control specific control can be specified using
-#'  \code{\link[minpack.lm]{nls.lm.control}}.
-#' @param modelweights Optional model weights for the nls. If \code{data} is specified, then this argument should be the name of the numeric weights vector within
-#'  the \code{data} object.
+#'   \code{\link[minpack.lm]{nls.lm.control}}.
+#' @param modelweights Optional model weights for the nls. If \code{data} is
+#'   specified, then this argument should be the name of the numeric weights
+#'   vector within the \code{data} object.
 #' @param \dots Extra arguments to pass to \code{\link[minpack.lm]{nlsLM}} if
-#'  necessary.
+#'   necessary.
 #' @return returns a nls object of the best estimated model fit.
-#' @note Useful additional arguments for \code{\link[minpack.lm]{nlsLM}} include:
-#'  \code{na.action = na.omit}, \code{lower/upper = c()} where these represent
-#'  upper and lower boundaries for parameter estimates.
+#' @note Useful additional arguments for \code{\link[minpack.lm]{nlsLM}}
+#'   include: \code{na.action = na.omit}, \code{lower/upper = c()} where these
+#'   represent upper and lower boundaries for parameter estimates.
 #' @author Daniel Padfield
 #' @author Granville Matheson
 #' @seealso \code{\link[minpack.lm]{nlsLM}} for details on additional arguments
-#' to pass to the nlsLM function.
+#'   to pass to the nlsLM function.
 #' @examples
 #' # load in data
 #'

--- a/R/nls_multstart.R
+++ b/R/nls_multstart.R
@@ -145,6 +145,12 @@ nls_multstart <-
     # transform input arguments
     silent <- ifelse(supp_errors == "Y", TRUE, FALSE)
 
+    # if silent is TRUE, temporarily switch off warnings
+    if(silent == TRUE){
+      oo <- options(warn=-1)
+      on.exit(options(oo))
+    }
+
     if ("modelweights" %in% all.vars(formula)) {
       stop(paste0(
         "The variable name 'modelweights' is reserved for model weights. Please change the name\n",
@@ -221,6 +227,7 @@ nls_multstart <-
         start.vals <- as.list(strt[j, ])
 
         # try and fit the model for every set of searching parameters
+
         try(
           fit <- minpack.lm::nlsLM(
             formula,

--- a/man/nls_multstart.Rd
+++ b/man/nls_multstart.Rd
@@ -12,38 +12,41 @@ the variables in \code{formula} and \code{modelweights}.}
 
 \item{iter}{number of combinations of starting parameters which will be tried
 . If a single value is provided, then a shotgun/random-search approach will
-be used to sample starting parameters from a uniform distribution within the
-starting parameter bounds. If a vector of the same length as the number of
-parameters is provided, then a gridstart approach will be used to define
+be used to sample starting parameters from a uniform distribution within
+the starting parameter bounds. If a vector of the same length as the number
+of parameters is provided, then a gridstart approach will be used to define
 each combination of that number of equally spaced intervals across each of
 the starting parameter bounds respectively. Thus, c(5,5,5) for three fitted
-parameters yields 125 model fits.  Supplying a vector for \code{iter}
-will override \code{convergence_count}.}
+parameters yields 125 model fits.  Supplying a vector for \code{iter} will
+override \code{convergence_count}.}
 
-\item{start_lower}{lower boundaries for the start parameters. If missing, this
-will default to -1e+10.}
+\item{start_lower}{lower boundaries for the start parameters. If missing,
+this will default to -1e+10.}
 
-\item{start_upper}{upper boundaries for the start parameters. If missing, this
-will default to 1e+10.}
+\item{start_upper}{upper boundaries for the start parameters. If missing,
+this will default to 1e+10.}
 
-\item{supp_errors}{if \code{supp_errors = 'Y'}, then warning messages will be suppressed and no error messages from
-\code{\link[minpack.lm]{nlsLM}} will be shown, reducing the number of error messages printed while the model attempts to converge using poor starting parameters.
-We advise to only use \code{supp_errors = 'Y'} when confident in the bounds of
- your starting parameters.}
+\item{supp_errors}{if \code{supp_errors = 'Y'}, then warning messages will be
+suppressed and no error messages from \code{\link[minpack.lm]{nlsLM}} will
+be shown, reducing the number of error messages printed while the model
+attempts to converge using poor starting parameters. We advise to only use
+\code{supp_errors = 'Y'} when confident in the bounds of your starting
+parameters.}
 
-\item{convergence_count}{The number of counts that the winning model should be
-undefeated for before it is declared the winner. This argument defaults to
-100. If specified as \code{FALSE}, then all of the iterations will be fitted, and
-the best model selected. Note that \code{convergence_count} can only be used
-with a shotgun/random-search approach, and not with a gridstart approach.
-This argument will be ignored if a gridstart approach is specified by a
-vector input for \code{iter}.}
+\item{convergence_count}{The number of counts that the winning model should
+be undefeated for before it is declared the winner. This argument defaults
+to 100. If specified as \code{FALSE}, then all of the iterations will be
+fitted, and the best model selected. Note that \code{convergence_count} can
+only be used with a shotgun/random-search approach, and not with a
+gridstart approach. This argument will be ignored if a gridstart approach
+is specified by a vector input for \code{iter}.}
 
 \item{control}{specific control can be specified using
 \code{\link[minpack.lm]{nls.lm.control}}.}
 
-\item{modelweights}{Optional model weights for the nls. If \code{data} is specified, then this argument should be the name of the numeric weights vector within
-the \code{data} object.}
+\item{modelweights}{Optional model weights for the nls. If \code{data} is
+specified, then this argument should be the name of the numeric weights
+vector within the \code{data} object.}
 
 \item{\dots}{Extra arguments to pass to \code{\link[minpack.lm]{nlsLM}} if
 necessary.}
@@ -52,13 +55,13 @@ necessary.}
 returns a nls object of the best estimated model fit.
 }
 \description{
-Finds the best estimated model using non-linear least squares regression using
-nlsLM(). The best fit is determined using AIC scores.
+Finds the best estimated model using non-linear least squares regression
+using nlsLM(). The best fit is determined using AIC scores.
 }
 \note{
-Useful additional arguments for \code{\link[minpack.lm]{nlsLM}} include:
- \code{na.action = na.omit}, \code{lower/upper = c()} where these represent
- upper and lower boundaries for parameter estimates.
+Useful additional arguments for \code{\link[minpack.lm]{nlsLM}}
+  include: \code{na.action = na.omit}, \code{lower/upper = c()} where these
+  represent upper and lower boundaries for parameter estimates.
 }
 \examples{
 # load in data
@@ -88,7 +91,7 @@ fits <- nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K, Tc = 
 }
 \seealso{
 \code{\link[minpack.lm]{nlsLM}} for details on additional arguments
-to pass to the nlsLM function.
+  to pass to the nlsLM function.
 }
 \author{
 Daniel Padfield


### PR DESCRIPTION
This relates to the issue here (https://github.com/padpadpadpad/nls.multstart/issues/17) where I proposed this change.  I have run into this same issue many times, and students of mine have also bumped up against it.  It's often caused by having a column in our data which has the same name as one of the parameters we want to estimate with `nls_multstart`.  We often have an independent estimate of one of the parameters, and we want to see whether we can fit it from the data.

In these cases, I will usually go into the debugger to figure out which variables are being estimated and which are not.  But I think having a more informative error message would make this more transparent for those who aren't familiar with this issue.

So in the example below, I've added a column for Th, when we might have thought we were going to be estimating it (and therefore left it in the `start_lower` and `start_upper` vectors).

```
fits <- nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K, Tc = 20),
                      data = Chlorella_TRC_test %>% mutate(Th = 300),
                      iter = 500,
                      start_lower = c(lnc=-10, E=0.1, Eh=0.5, Th=285),
                      start_upper = c(lnc=10, E=2, Eh=5, Th=330),
                      lower = c(lnc=-10, E=0, Eh=0, Th=0),
                      supp_errors = 'Y')
```

The new error message we get should hopefully make it more clear why the model is not working

```
Error in nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K,  : 
  There must be as many parameter starting bounds as there are parameters.

Parameters to estimate:              lnc E Eh
Parameters supplied as input data:   Th K
Number of parameters in start_lower: 4
Number of parameters in start_upper: 4

If there are parameters listed as input data which should be estimated,
this can be caused by variables in the environment/data with the same
name as model parameters.
``` 

While I was at it, I got a warning about the Roxygen version being out of date, so I updated that.  I also reflowed the comments at the start as they were passing the 80 character limit.

Lastly, I get an error on the Github actions build.  Apparently there are new routines.  I tried to add them using `use_github_actions_badge(name = "R-CMD-check.yaml")`, but apparently it doesn't work if my upstream (i.e. my fork) is not the origin parent (your original version).  So I think maybe you need to update it.