### PR TITLE
Add Latin Hypercube Sampling approach for generating starting values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,14 +10,16 @@ Description: Non-linear least squares regression with the Levenberg-Marquardt al
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Depends:
     R (>= 3.2.1)
-Imports: minpack.lm,
+Imports: 
+    minpack.lm,
     purrr,
     dplyr,
     tidyr,
-    tibble
+    tibble,
+    lhs
 Suggests: 
     ggplot2,
     broom,

--- a/man/nls_multstart.Rd
+++ b/man/nls_multstart.Rd
@@ -11,14 +11,14 @@
 the variables in \code{formula} and \code{modelweights}.}
 
 \item{iter}{number of combinations of starting parameters which will be tried
-. If a single value is provided, then a shotgun/random-search approach will
-be used to sample starting parameters from a uniform distribution within
-the starting parameter bounds. If a vector of the same length as the number
-of parameters is provided, then a gridstart approach will be used to define
-each combination of that number of equally spaced intervals across each of
-the starting parameter bounds respectively. Thus, c(5,5,5) for three fitted
-parameters yields 125 model fits.  Supplying a vector for \code{iter} will
-override \code{convergence_count}.}
+. If a single value is provided, then a shotgun/random-search/lhs approach
+will be used to sample starting parameters from a uniform distribution
+within the starting parameter bounds. If a vector of the same length as the
+number of parameters is provided, then a gridstart approach will be used to
+define each combination of that number of equally spaced intervals across
+each of the starting parameter bounds respectively. Thus, c(5,5,5) for
+three fitted parameters yields 125 model fits.  Supplying a vector for
+\code{iter} will override \code{convergence_count}.}
 
 \item{start_lower}{lower boundaries for the start parameters. If missing,
 this will default to -1e+10.}
@@ -47,6 +47,14 @@ is specified by a vector input for \code{iter}.}
 \item{modelweights}{Optional model weights for the nls. If \code{data} is
 specified, then this argument should be the name of the numeric weights
 vector within the \code{data} object.}
+
+\item{lhstype}{Method to use for Latin Hypercube Sampling. Choice of
+\code{"random"} (simple random lhs, fast), \code{"improved"} (lhs with
+optimised euclidean distance between points, medium speed), \code{"maximin"}
+(lhs with maximised minimum distance between points, medium speed), or
+\code{"genetic"} (lhs optimised to the S optimilaity criterion using a
+genetic algorithm, slow). If not set, a purely random (shotgun) approach is
+taken. Only used if \code{iter} is a single number.}
 
 \item{\dots}{Extra arguments to pass to \code{\link[minpack.lm]{nlsLM}} if
 necessary.}
@@ -97,4 +105,6 @@ fits <- nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K, Tc = 
 Daniel Padfield
 
 Granville Matheson
+
+Francis Windram
 }

--- a/tests/testthat/test-nls_multstart.R
+++ b/tests/testthat/test-nls_multstart.R
@@ -29,6 +29,18 @@ test_that("fit with convergence works", {
     c(lnc=-1, E=1, Eh=4, Th=312) )
 })
 
+test_that("fit with LHS works", {
+  expect_equal(
+    round( coef(nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K, Tc = 20),
+                              data = Chlorella_TRC_test,
+                              iter = 500,
+                              start_lower = c(-10, 0.1, 0.5, 285),
+                              start_upper = c(10, 2, 5, 330),
+                              lower = c(lnc=-10, E=0, Eh=0, Th=0),
+                              supp_errors = 'Y', lhstype = "random") )),
+    c(lnc=-1, E=1, Eh=4, Th=312) )
+})
+
 test_that("fit without convergence works", {
   expect_equal(
     round( coef(nls_multstart(ln.rate ~ schoolfield_high(lnc, E, Eh, Th, temp = K, Tc = 20),


### PR DESCRIPTION
This PR adds a Latin Hypercube Sampling approach to the shotgun method of generating starting values.

Instead of sampling from a uniform distribution across every parameter, this instead tries to take a set of samples from the range of parameter values that covers the parameter space optimally for any given set of parameters. 

In practice this is sort of a halfway approach between gridstart and shotgun. On testing with tricky TPCs to fit, like flexTPC, generally it requires 60% of the number of samples to get a similar reliability of fitting.

In the end providing choices in multiple-fit approach is good as NLS fitting is generally not a one-size-fits-all system.

In theory this could fully supplant the shotgun approach (as it's basically a more optimised version), however at least for now this can just stay as an option.