### PR TITLE
Substitute stop/warning calls for cli equivalents.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,9 @@ Imports:
     dplyr,
     tidyr,
     tibble,
-    lhs
+    lhs,
+    cli,
+    rlang
 Suggests: 
     ggplot2,
     broom,


### PR DESCRIPTION
This PR substitutes base R stop/warn/cat commands with equivalents from `cli`.

The main upside of using `cli` is that given its powerful formatting system, shifting over to it will allow future releases to incorporate more detailed and usable feedback for users.